### PR TITLE
修复一个异常捕捉bug，只捕捉了没有抛出，导致任务实际上失败，但是却返回成功

### DIFF
--- a/src/main/java/com/jiladahe1997/embeddedproxy/scheduling/JobARM.java
+++ b/src/main/java/com/jiladahe1997/embeddedproxy/scheduling/JobARM.java
@@ -27,7 +27,7 @@ public class JobARM {
                 Utils.downloadFileFromUrl(c.url,c.fileName);
                 Utils.uploadFile(c.fileName);
             } catch (IOException e) {
-                e.printStackTrace();
+                throw new RuntimeException(e);
             }
         });
         return ReturnT.SUCCESS;


### PR DESCRIPTION
修复一个异常捕捉bug，只捕捉了没有抛出，导致任务实际上失败，但是却返回成功